### PR TITLE
add file extension management

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ The configuration file is defined as follows:
 
 - The `vault` section contains all configuration related to the note vault
   - `path` contains the full path to the vault main directory
+  - `extension` contains the extension of the notes files in your vault (with dot)
 - The `journal` section contains all configuration related to the journal notes:
   - `directory` contains the path, relative to `vault.path`,
     where to store your journal notes
@@ -97,6 +98,7 @@ Here's an exhaustive configuration example:
 # Contains all vault specific options
 vault:
   path: $HOME/vault # Default: $HOME/thoughtsync
+  extension: ".txt" # Default: ".md"
 
 journal:
   directory: my-own-journal # Default: journal

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ The configuration file is defined as follows:
   - `extension` contains the extension of the notes files in your vault (with dot)
 - The `journal` section contains all configuration related to the journal notes:
   - `directory` contains the path, relative to `vault.path`,
-    where to store your journal notes
+    to store your journal notes in
   - `format` defines the format used to give a name to your journal
     notes, such as "2006-02-01", without extension
     - currently supported formats are `YYYY-MM-DD`, `MM-DD-YYYY`

--- a/cmd/config/config.go
+++ b/cmd/config/config.go
@@ -16,8 +16,10 @@ const (
 
 	// Keys in the config file with default values
 	// Vault path
-	VAULT_KEY          = "vault.path"
-	DEFAULT_VAULT_PATH = "$HOME/thoughtsync-vault"
+	VAULT_KEY                     = "vault.path"
+	DEFAULT_VAULT_PATH            = "$HOME/thoughtsync-vault"
+	VAULT_NOTES_EXTENSION_KEY     = "vault.extension"
+	DEFAULT_VAULT_NOTES_EXTENSION = ".md"
 
 	// Journal note format
 	JOURNAL_NOTE_FORMAT_KEY = "journal.format"
@@ -39,6 +41,7 @@ func InitConfig() {
 	viper.SetDefault(VAULT_KEY, DEFAULT_VAULT_PATH)
 	viper.SetDefault(JOURNAL_NOTE_FORMAT_KEY, DEFAULT_JOURNAL_FORMAT)
 	viper.SetDefault(JOURNAL_DIRECTORY_KEY, DEFAULT_JOURNAL_DIRECTORY)
+	viper.SetDefault(VAULT_NOTES_EXTENSION_KEY, DEFAULT_VAULT_NOTES_EXTENSION)
 
 	if err := viper.ReadInConfig(); err != nil {
 		os.Exit(1)

--- a/cmd/new.go
+++ b/cmd/new.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 
 	gopath "path"
+	filepath "path/filepath"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -17,13 +18,16 @@ import (
 
 // NewNote opens the given file filename in vaultType, optionally in directory
 // noteType, using the editor provided
-func NewNote(editor editor.Editor, vaultPath, noteType, filename string) error {
+func NewNote(editor editor.Editor, vaultPath, noteType, filename, fileExtension string) error {
 	folderPath := gopath.Join(vaultPath, noteType)
 	err := path.EnsurePresent(folderPath, filename)
 	if err != nil {
 		return fmt.Errorf("error in ensure present for dir %s, file %s: %v", folderPath, filename, err)
 	}
 	fullPath := gopath.Join(folderPath, filename)
+	if filepath.Ext(fullPath) != fileExtension {
+		fullPath += fileExtension
+	}
 	err = editor.Edit(fullPath)
 	if err != nil {
 		return fmt.Errorf("error in write: %v", err)
@@ -41,7 +45,8 @@ func init() {
 			filename := args[0]
 			vaultPath := viper.GetString(config.VAULT_KEY)
 			noteType, _ := cmd.Flags().GetString("type")
-			return NewNote(editor, vaultPath, noteType, filename)
+			fileExtension := viper.GetString(config.VAULT_NOTES_EXTENSION_KEY)
+			return NewNote(editor, vaultPath, noteType, filename, fileExtension)
 		},
 	}
 	newCmd.Flags().StringP("type", "t", "", "Folder of the note vault to put the new note in")

--- a/cmd/new.go
+++ b/cmd/new.go
@@ -45,12 +45,12 @@ func init() {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			filename := args[0]
 			vaultPath := viper.GetString(config.VAULT_KEY)
-			noteType, _ := cmd.Flags().GetString("type")
+			noteType, _ := cmd.Flags().GetString("dir")
 			fileExtension := viper.GetString(config.VAULT_NOTES_EXTENSION_KEY)
 			return NewNote(editor, vaultPath, noteType, filename, fileExtension)
 		},
 	}
-	newCmd.Flags().StringP("type", "t", "", "Folder of the note vault to put the new note in")
+	newCmd.Flags().StringP("dir", "d", "", "Vault directory to put the new note in")
 
 	RootCmd.AddCommand(newCmd)
 }

--- a/cmd/new.go
+++ b/cmd/new.go
@@ -20,14 +20,15 @@ import (
 // noteType, using the editor provided
 func NewNote(editor editor.Editor, vaultPath, noteType, filename, fileExtension string) error {
 	folderPath := gopath.Join(vaultPath, noteType)
-	err := path.EnsurePresent(folderPath, filename)
+	completeFilename := filename
+	if filepath.Ext(filename) != fileExtension {
+		completeFilename += fileExtension
+	}
+	err := path.EnsurePresent(folderPath, completeFilename)
 	if err != nil {
 		return fmt.Errorf("error in ensure present for dir %s, file %s: %v", folderPath, filename, err)
 	}
-	fullPath := gopath.Join(folderPath, filename)
-	if filepath.Ext(fullPath) != fileExtension {
-		fullPath += fileExtension
-	}
+	fullPath := gopath.Join(folderPath, completeFilename)
 	err = editor.Edit(fullPath)
 	if err != nil {
 		return fmt.Errorf("error in write: %v", err)
@@ -46,6 +47,7 @@ func init() {
 			vaultPath := viper.GetString(config.VAULT_KEY)
 			noteType, _ := cmd.Flags().GetString("type")
 			fileExtension := viper.GetString(config.VAULT_NOTES_EXTENSION_KEY)
+			fmt.Printf("extension: %s\n", fileExtension)
 			return NewNote(editor, vaultPath, noteType, filename, fileExtension)
 		},
 	}

--- a/cmd/new.go
+++ b/cmd/new.go
@@ -47,7 +47,6 @@ func init() {
 			vaultPath := viper.GetString(config.VAULT_KEY)
 			noteType, _ := cmd.Flags().GetString("type")
 			fileExtension := viper.GetString(config.VAULT_NOTES_EXTENSION_KEY)
-			fmt.Printf("extension: %s\n", fileExtension)
 			return NewNote(editor, vaultPath, noteType, filename, fileExtension)
 		},
 	}

--- a/cmd/today.go
+++ b/cmd/today.go
@@ -19,8 +19,8 @@ import (
 
 // OpenTodayNote opens the today note with name filename in the vault directory
 // vaultJournalPath using the editor provider
-func OpenTodayNote(editor editor.Editor, vaultJournalPath, filename string) error {
-	filenameMd := fmt.Sprintf("%s.md", filename)
+func OpenTodayNote(editor editor.Editor, vaultJournalPath, filename, extension string) error {
+	filenameMd := filename + extension
 	err := path.EnsurePresent(vaultJournalPath, filenameMd)
 	if err != nil {
 		return fmt.Errorf("failed to ensure present: %w", err)
@@ -44,10 +44,11 @@ func init() {
 			journalDir := viper.GetString(config.JOURNAL_DIRECTORY_KEY)
 			vaultJournalPath := gopath.Join(vaultPath, journalDir)
 			filename, err := date.Format(time.Now(), format)
+			fileExtension := viper.GetString(config.VAULT_NOTES_EXTENSION_KEY)
 			if err != nil {
 				return fmt.Errorf("error getting journal filename: %w", err)
 			}
-			return OpenTodayNote(editor, vaultJournalPath, filename)
+			return OpenTodayNote(editor, vaultJournalPath, filename, fileExtension)
 		},
 	}
 	RootCmd.AddCommand(todayCmd)

--- a/test/cmd/new_test.go
+++ b/test/cmd/new_test.go
@@ -2,8 +2,10 @@ package cmd
 
 import (
 	"ThoughtSync/cmd"
+	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -13,6 +15,11 @@ type NewNoteTestSuite struct {
 
 func (suite *NewNoteTestSuite) TestNewNoteCmd() {
 	err := cmd.NewNote(suite.editor, suite.vaultPath, "", "test", ".txt")
+
+	filenameWithExtension := "test.txt"
+
+	suite.editor.AssertCalled(suite.T(), "Edit",
+		mock.MatchedBy(func(expected string) bool { return strings.Contains(expected, filenameWithExtension) }))
 	suite.Assert().Nil(err)
 }
 

--- a/test/cmd/new_test.go
+++ b/test/cmd/new_test.go
@@ -12,7 +12,7 @@ type NewNoteTestSuite struct {
 }
 
 func (suite *NewNoteTestSuite) TestNewNoteCmd() {
-	err := cmd.NewNote(suite.editor, suite.vaultPath, "", "test.txt")
+	err := cmd.NewNote(suite.editor, suite.vaultPath, "", "test", ".txt")
 	suite.Assert().Nil(err)
 }
 

--- a/test/cmd/today_test.go
+++ b/test/cmd/today_test.go
@@ -2,8 +2,10 @@ package cmd
 
 import (
 	"ThoughtSync/cmd"
+	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -12,8 +14,12 @@ type TodayNoteTestSuite struct {
 }
 
 func (suite *TodayNoteTestSuite) TestNewNoteCmd() {
-	err := cmd.OpenTodayNote(suite.editor, suite.vaultPath, "2006-02-01")
+	err := cmd.OpenTodayNote(suite.editor, suite.vaultPath, "2006-02-01", ".md")
 	suite.Assert().Nil(err)
+	filenameWithExtension := "2006-02-01.md"
+
+	suite.editor.AssertCalled(suite.T(), "Edit",
+		mock.MatchedBy(func(expected string) bool { return strings.Contains(expected, filenameWithExtension) }))
 }
 
 func TestTodayNoteTestSuite(t *testing.T) {


### PR DESCRIPTION
Adds file extension management. In particular:
- Adds a configurable file extension used for files created with the `new` and `today` commands
- Uses the configured extension if the filename provided to the `new` command does not include it