### PR TITLE
Inbox note

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ The following is a list of available commands:
 - `thoughtsync today` to create and/or open the journal note of today
 - `thoughtsync inbox` to quickly opne an inbox note to store thoughts and ideas,
   to be processed later
+- `thoughtsync open` to open the vault directory in your editor
 - `thoughtysync git` contains all git-related commands:
   - `sync` to stage, commit and optionally push your vault to
     your remote git repository.

--- a/README.md
+++ b/README.md
@@ -94,6 +94,8 @@ The following is a list of available commands:
 
 - `thoughtsync new <filename.txt>` to create a new note in your vault
 - `thoughtsync today` to create and/or open the journal note of today
+- `thoughtsync inbox` to quickly opne an inbox note to store thoughts and ideas,
+  to be processed later
 - `thoughtysync git` contains all git-related commands:
   - `sync` to stage, commit and optionally push your vault to
     your remote git repository.

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -49,6 +49,7 @@ func init() {
 		Use:     "config",
 		Short:   "Contains all commands related to thoughtsync configuration",
 		Aliases: []string{"c"},
+		Args:    cobra.ExactArgs(0),
 		Run: func(cmd *cobra.Command, args []string) {
 			getConfig()
 		},

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -1,3 +1,6 @@
+/*
+Copyright © 2024 Leonardo Campitelli leonardo932.campitelli@gmail.com
+*/
 package cmd
 
 import (

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -44,6 +44,7 @@ func setConfig(configKey, configValue string) {
 func init() {
 	getConfigCmd := &cobra.Command{
 		Use:     "config",
+		Short:   "Contains all commands related to thoughtsync configuration",
 		Aliases: []string{"c"},
 		Run: func(cmd *cobra.Command, args []string) {
 			getConfig()

--- a/cmd/config/config.go
+++ b/cmd/config/config.go
@@ -53,6 +53,10 @@ const (
 	DEFAULT_GIT_AUTH_SSH       = false
 	GIT_REMOTE_NAME_KEY        = "git.remote-name"
 	DEFAULT_GIT_REMOTE_NAME    = "origin"
+
+	// Inbox catch-all note
+	INBOX_NOTE_KEY     = "vault.inbox"
+	DEFAULT_INBOX_NOTE = "inbox"
 )
 
 // InitConfig Loads in ThoughtSync config
@@ -74,6 +78,8 @@ func InitConfig() {
 	viper.SetDefault(GIT_AUTH_SSH_KEY, DEFAULT_GIT_AUTH_SSH)
 	viper.SetDefault(GIT_REMOTE_NAME_KEY, DEFAULT_GIT_REMOTE_NAME)
 	viper.SetDefault(VAULT_NOTES_EXTENSION_KEY, DEFAULT_VAULT_NOTES_EXTENSION)
+
+	viper.SetDefault(INBOX_NOTE_KEY, DEFAULT_INBOX_NOTE)
 
 	if err := viper.ReadInConfig(); err != nil {
 		color.Red("error in reading configuration: %v", err.Error())

--- a/cmd/git.go
+++ b/cmd/git.go
@@ -75,12 +75,15 @@ func VaultGitPull(repository repository.Repository) error {
 
 func init() {
 	gitCmd := &cobra.Command{
-		Use:   "git",
-		Short: "Git related commands",
+		Use:     "git",
+		Short:   "Contains all commands related to Git",
+		Args:    cobra.ExactArgs(0),
+		Aliases: []string{"g"},
 	}
 	syncCmd := &cobra.Command{
 		Use:   "sync",
 		Short: "Stage, commit and push all changes in your note vault to your remote repository",
+		Args:  cobra.ExactArgs(0),
 		Run: func(cmd *cobra.Command, args []string) {
 			gitSyncEnabled := viper.GetBool(config.GIT_SYNC_ENABLED_KEY)
 			if !gitSyncEnabled {
@@ -109,6 +112,7 @@ func init() {
 	statusCmd := &cobra.Command{
 		Use:   "status",
 		Short: "Print out the git status of your vault repo",
+		Args:  cobra.ExactArgs(0),
 		Run: func(cmd *cobra.Command, args []string) {
 			gitSyncEnabled := viper.GetBool(config.GIT_SYNC_ENABLED_KEY)
 			if !gitSyncEnabled {
@@ -133,6 +137,7 @@ func init() {
 	pushCmd := &cobra.Command{
 		Use:   "push",
 		Short: "Push changes to the vault remote git repo",
+		Args:  cobra.ExactArgs(0),
 		Run: func(cmd *cobra.Command, args []string) {
 			gitSyncEnabled := viper.GetBool(config.GIT_SYNC_ENABLED_KEY)
 			if !gitSyncEnabled {
@@ -158,6 +163,7 @@ func init() {
 	pullCmd := &cobra.Command{
 		Use:   "pull",
 		Short: "Pull changes from the vault remote git repo",
+		Args:  cobra.ExactArgs(0),
 		Run: func(cmd *cobra.Command, args []string) {
 			gitSyncEnabled := viper.GetBool(config.GIT_SYNC_ENABLED_KEY)
 			if !gitSyncEnabled {

--- a/cmd/inbox.go
+++ b/cmd/inbox.go
@@ -38,9 +38,10 @@ func OpenInboxNote(editor editor.Editor, vaultPath, inboxNotePath, fileExtension
 func init() {
 	editor := editor.NewEditor()
 	InboxCmd := &cobra.Command{
-		Use:   "inbox",
-		Short: "Creates and opens your inbox note in your $EDITOR",
-		Args:  cobra.ExactArgs(0),
+		Use:     "inbox",
+		Short:   "Creates and opens your inbox note in your $EDITOR",
+		Args:    cobra.ExactArgs(0),
+		Aliases: []string{"i"},
 		Run: func(cmd *cobra.Command, args []string) {
 			vaultPath := viper.GetString(config.VAULT_KEY)
 			fileExtension := viper.GetString(config.VAULT_NOTES_EXTENSION_KEY)

--- a/cmd/inbox.go
+++ b/cmd/inbox.go
@@ -1,3 +1,6 @@
+/*
+Copyright © 2024 Leonardo Campitelli leonardo932.campitelli@gmail.com
+*/
 package cmd
 
 import (

--- a/cmd/inbox.go
+++ b/cmd/inbox.go
@@ -1,0 +1,53 @@
+package cmd
+
+import (
+	"fmt"
+	gopath "path"
+	filepath "path/filepath"
+
+	"github.com/lcampit/ThoughtSync/cmd/config"
+	"github.com/lcampit/ThoughtSync/cmd/editor"
+	"github.com/lcampit/ThoughtSync/cmd/path"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+func OpenInboxNote(editor editor.Editor, vaultPath, inboxNotePath, fileExtension string) error {
+	completeFilename := gopath.Base(inboxNotePath)
+
+	inboxDirPath := gopath.Dir(inboxNotePath)
+	if filepath.Ext(inboxNotePath) != fileExtension {
+		completeFilename += fileExtension
+	}
+	folderPath := gopath.Join(vaultPath, inboxDirPath)
+	err := path.EnsurePresent(folderPath, completeFilename)
+	if err != nil {
+		return fmt.Errorf("error in ensure present for dir %s, file %s: %v", folderPath, completeFilename, err)
+	}
+	fullPath := gopath.Join(folderPath, completeFilename)
+	err = editor.Edit(fullPath)
+	if err != nil {
+		return fmt.Errorf("error in write: %v", err)
+	}
+	return nil
+}
+
+func init() {
+	editor := editor.NewEditor()
+	InboxCmd := &cobra.Command{
+		Use:   "inbox",
+		Short: "Creates and opens your inbox note in your $EDITOR",
+		Args:  cobra.ExactArgs(0),
+		Run: func(cmd *cobra.Command, args []string) {
+			vaultPath := viper.GetString(config.VAULT_KEY)
+			fileExtension := viper.GetString(config.VAULT_NOTES_EXTENSION_KEY)
+			inboxNotePath := viper.GetString(config.INBOX_NOTE_KEY)
+			err := OpenInboxNote(editor, vaultPath, inboxNotePath, fileExtension)
+			if err != nil {
+				Printer.PlainError(err)
+			}
+		},
+	}
+
+	RootCmd.AddCommand(InboxCmd)
+}

--- a/cmd/new.go
+++ b/cmd/new.go
@@ -39,9 +39,10 @@ func NewNote(editor editor.Editor, vaultPath, noteType, filename, fileExtension 
 func init() {
 	editor := editor.NewEditor()
 	newCmd := &cobra.Command{
-		Use:   "new -t <type> <filename>",
-		Short: "Creates and opens the given file in your $EDITOR",
-		Args:  cobra.ExactArgs(1),
+		Use:     "new -t <type> <filename>",
+		Short:   "Creates and opens the given file in your $EDITOR",
+		Args:    cobra.ExactArgs(1),
+		Aliases: []string{"n"},
 		Run: func(cmd *cobra.Command, args []string) {
 			filename := args[0]
 			vaultPath := viper.GetString(config.VAULT_KEY)

--- a/cmd/open.go
+++ b/cmd/open.go
@@ -1,0 +1,45 @@
+/*
+Copyright © 2024 Leonardo Campitelli leonardo932.campitelli@gmail.com
+*/
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/lcampit/ThoughtSync/cmd/config"
+	"github.com/lcampit/ThoughtSync/cmd/editor"
+	"github.com/lcampit/ThoughtSync/cmd/path"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+func OpenVaultDir(editor editor.Editor, vaultPath string) error {
+	err := path.CreateFolders(vaultPath)
+	if err != nil {
+		return fmt.Errorf("error creating dirs to vault path: %s: %v", vaultPath, err)
+	}
+	err = editor.Edit(vaultPath)
+	if err != nil {
+		return fmt.Errorf("error in write: %v", err)
+	}
+	return nil
+}
+
+func init() {
+	editor := editor.NewEditor()
+	OpenCmd := &cobra.Command{
+		Use:     "open",
+		Aliases: []string{"o"},
+		Short:   "Opens the vault directory in your $EDITOR",
+		Args:    cobra.ExactArgs(0),
+		Run: func(cmd *cobra.Command, args []string) {
+			vaultPath := viper.GetString(config.VAULT_KEY)
+			err := OpenVaultDir(editor, vaultPath)
+			if err != nil {
+				Printer.PlainError(err)
+			}
+		},
+	}
+
+	RootCmd.AddCommand(OpenCmd)
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -17,8 +17,8 @@ var RootCmd = &cobra.Command{
 	Use:   "ThoughtSync",
 	Short: "A tool to manage your notes",
 	Long: `ThoughtSync is a CLI tool that helps command line power users 
-  in managing their notes. It allows to create and edit notes at 
-  the speed of thought`,
+  managing their notes. It allows to create and edit notes at 
+  the speed of thought from anywhere, without leaving the terminal.`,
 }
 
 // Global logger

--- a/cmd/today.go
+++ b/cmd/today.go
@@ -35,8 +35,10 @@ func OpenTodayNote(editor editor.Editor, vaultJournalPath, filename, extension s
 func init() {
 	editor := editor.NewEditor()
 	todayCmd := &cobra.Command{
-		Use:   "today",
-		Short: "Quickly edit the journal note for today",
+		Use:     "today",
+		Short:   "Quickly edit the journal note for today",
+		Aliases: []string{"t"},
+		Args:    cobra.ExactArgs(0),
 		Run: func(cmd *cobra.Command, args []string) {
 			vaultPath := viper.GetString(config.VAULT_KEY)
 			format := viper.GetString(config.JOURNAL_NOTE_FORMAT_KEY)


### PR DESCRIPTION
Updates commands with aliases and exact args requirements 
Adds the `inbox` command, which opens a catch-all inbox note in the notes vault 
Adds the `open` command, which opens the vault root directory in the editor 

Update documentation